### PR TITLE
Feature optional restart

### DIFF
--- a/phytronApp/src/README.txt
+++ b/phytronApp/src/README.txt
@@ -5,7 +5,9 @@ Authors: Tom Slejko, Bor Marolt, Cosylab d.d.
 		tom.slejko@cosylab.com
 		bor.marolt@cosylab.com
 	 Lutz Rossa, Helmholtz-Zentrum Berlin fuer Materialien und Energy GmbH
+   Will Smith, Helmholtz-Zentrum Berlin fuer Materialien und Energy GmbH
 		rossa@helmholtz-berlin.de
+    william.smith@helmholtz-berlin.de
 
 ********************************************************************************
 Table of contents:
@@ -90,12 +92,13 @@ Phytron (MCM) controller port is configured (and connected to previously created
 asyn port) by running the following iocsh function:
 
 phytronCreateController(const char *phytronPortName, const char *asynPortName,
-                int movingPollPeriod, int idlePollPeriod, double timeout)
+                int movingPollPeriod, int idlePollPeriod, double timeout, int noResetAtBoot)
 - phytronPortName: Name of the particular MCM unit.
 - asynPortName: Name of the previously configured asyn port - interface to MCM
 - movingPollPeriod: The time between polls when any axis is moving in ms
 - idlePolPeriod: The time between polls when no axis is moving in ms
 - Timeout: Milliseconds before timeout for I/O requests
+- noResetAtBoot: if 1 then the controller is not reset at boot. If unset or 0 it is
 
 where poll reads the basic axis status, e.g. position of the motor and of the 
 encoder, checks if axis is in movement, checks if motor is at the limit 

--- a/phytronApp/src/phytronAxisMotor.cpp
+++ b/phytronApp/src/phytronAxisMotor.cpp
@@ -80,9 +80,10 @@ static vector<phytronController*> controllers;
   * \param[in] phytronPortName   The name of the drvAsynIPPort that was created previously to connect to the phytron controller
   * \param[in] movingPollPeriod  The time between polls when any axis is moving
   * \param[in] idlePollPeriod    The time between polls when no axis is moving
+  * \param[in] noResetAtBoot     if 0 or not set then controller is reset, if 1 then it's not 
   */
 phytronController::phytronController(const char *phytronPortName, const char *asynPortName,
-                                     double movingPollPeriod, double idlePollPeriod, double timeout)
+                                     double movingPollPeriod, double idlePollPeriod, double timeout, bool noResetAtBoot)
   :  asynMotorController(phytronPortName,
                          0xFF,
                          NUM_PHYTRON_PARAMS,
@@ -159,13 +160,16 @@ phytronController::phytronController(const char *phytronPortName, const char *as
     //phytronCreateAxis will search for the controller for axis registration
     controllers.push_back(this);
 
-    //RESET THE CONTROLLER
-    //if (sendPhytronCommand(std::string("CR")))
-    //  asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING,
-    //        "phytronController::phytronController: Could not reset controller %s\n", this->controllerName_);
+    if (noResetAtBoot != 1){
+      //RESET THE CONTROLLER
+      if (sendPhytronCommand(std::string("CR")))
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING,
+              "phytronController::phytronController: Could not reset controller %s\n", this->controllerName_);
 
-    //Wait for reset to finish
-    //epicsThreadSleep(10.0);
+      //Wait for reset to finish
+      epicsThreadSleep(10.0);
+    }  
+
 
     startPoller(movingPollPeriod, idlePollPeriod, 5);
   }
@@ -178,11 +182,12 @@ phytronController::phytronController(const char *phytronPortName, const char *as
   * \param[in] numController     number of axes that this controller supports is numController*AXES_PER_CONTROLLER
   * \param[in] movingPollPeriod  The time in ms between polls when any axis is moving
   * \param[in] idlePollPeriod    The time in ms between polls when no axis is moving
+  * \param[in] noResetAtBoot     if 0 or not set then controller is reset, if 1 then it's not
   */
 extern "C" int phytronCreateController(const char *phytronPortName, const char *asynPortName,
-                                   int movingPollPeriod, int idlePollPeriod, double timeout)
+                                   int movingPollPeriod, int idlePollPeriod, double timeout, int noResetAtBoot)
 {
-  new phytronController(phytronPortName, asynPortName, movingPollPeriod/1000., idlePollPeriod/1000., timeout);
+  new phytronController(phytronPortName, asynPortName, movingPollPeriod/1000., idlePollPeriod/1000., timeout,noResetAtBoot);
   return asynSuccess;
 }
 
@@ -1524,11 +1529,13 @@ static const iocshArg phytronCreateControllerArg1 = {"PhytronAxis port name", io
 static const iocshArg phytronCreateControllerArg2 = {"Moving poll period (ms)", iocshArgInt};
 static const iocshArg phytronCreateControllerArg3 = {"Idle poll period (ms)", iocshArgInt};
 static const iocshArg phytronCreateControllerArg4 = {"Timeout (ms)", iocshArgDouble};
+static const iocshArg phytronCreateControllerArg5 = {"Do not restart controller with IOC", iocshArgInt};
 static const iocshArg * const phytronCreateControllerArgs[] = {&phytronCreateControllerArg0,
                                                              &phytronCreateControllerArg1,
                                                              &phytronCreateControllerArg2,
                                                              &phytronCreateControllerArg3,
-                                                             &phytronCreateControllerArg4};
+                                                             &phytronCreateControllerArg4,
+                                                             &phytronCreateControllerArg5};
 
 /** Parameters for iocsh phytron brake(s) output registration */
 static const iocshArg phytronBrakeOutputArg0 = {"Controller Name", iocshArgString};
@@ -1545,12 +1552,12 @@ static const iocshArg* const phytronBrakeOutputArgs[] = {&phytronBrakeOutputArg0
                                                          &phytronBrakeOutputArg5};
 
 static const iocshFuncDef phytronCreateAxisDef = {"phytronCreateAxis", 3, phytronCreateAxisArgs};
-static const iocshFuncDef phytronCreateControllerDef = {"phytronCreateController", 5, phytronCreateControllerArgs};
+static const iocshFuncDef phytronCreateControllerDef = {"phytronCreateController", 6, phytronCreateControllerArgs};
 static const iocshFuncDef phytronBrakeOutputDef = {"phytronBrakeOutput", 6, phytronBrakeOutputArgs};
 
 static void phytronCreateControllerCallFunc(const iocshArgBuf *args)
 {
-  phytronCreateController(args[0].sval, args[1].sval, args[2].ival, args[3].ival, args[4].dval);
+  phytronCreateController(args[0].sval, args[1].sval, args[2].ival, args[3].ival, args[4].dval,args[5].ival);
 }
 
 static void phytronCreateAxisCallFunc(const iocshArgBuf *args)

--- a/phytronApp/src/phytronAxisMotor.cpp
+++ b/phytronApp/src/phytronAxisMotor.cpp
@@ -160,12 +160,12 @@ phytronController::phytronController(const char *phytronPortName, const char *as
     controllers.push_back(this);
 
     //RESET THE CONTROLLER
-    if (sendPhytronCommand(std::string("CR")))
-      asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING,
-            "phytronController::phytronController: Could not reset controller %s\n", this->controllerName_);
+    //if (sendPhytronCommand(std::string("CR")))
+    //  asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING,
+    //        "phytronController::phytronController: Could not reset controller %s\n", this->controllerName_);
 
     //Wait for reset to finish
-    epicsThreadSleep(10.0);
+    //epicsThreadSleep(10.0);
 
     startPoller(movingPollPeriod, idlePollPeriod, 5);
   }

--- a/phytronApp/src/phytronAxisMotor.h
+++ b/phytronApp/src/phytronAxisMotor.h
@@ -143,7 +143,7 @@ friend class phytronController;
 class phytronController : public asynMotorController
 {
 public:
-  phytronController(const char *portName, const char *phytronPortName, double movingPollPeriod, double idlePollPeriod, double timeout);
+  phytronController(const char *portName, const char *phytronPortName, double movingPollPeriod, double idlePollPeriod, double timeout, bool resetAtBoot);
   asynStatus readInt32(asynUser *pasynUser, epicsInt32 *value);
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
   asynStatus readFloat64(asynUser *pasynUser, epicsFloat64 *value);


### PR DESCRIPTION
I added the ability to optionally reset the controller when the IOC is restarted. This is useful if you want to preserve the step counters on each axis. 

in st.cmd.phytron file 

```
#phytronCreateController (phytronPort, asynPort, movingPollPeriod, idlePollPeriod, timeout,noResetAtBoot)
phytronCreateController ("phyMotionPort", "testRemote", 100, 100, 1000,1)
```

Will disable reset. While

```
#phytronCreateController (phytronPort, asynPort, movingPollPeriod, idlePollPeriod, timeout,noResetAtBoot)
phytronCreateController ("phyMotionPort", "testRemote", 100, 100, 1000,0)
```

or 

```
#phytronCreateController (phytronPort, asynPort, movingPollPeriod, idlePollPeriod, timeout,noResetAtBoot)
phytronCreateController ("phyMotionPort", "testRemote", 100, 100, 1000)
```

would leave functionality unchanged and controller is reset. 

I had to put it in here at the initialization of the controller rather than an asyn setting after the port is created, because this parameter is only important at init time. 